### PR TITLE
Add ability to run tests from `phoenix-rtos-tests`

### DIFF
--- a/_projects/host-generic-pilot/build.project
+++ b/_projects/host-generic-pilot/build.project
@@ -23,11 +23,3 @@ b_build_project () {
 b_image_project () {
 	b_log "The images have been built for the ${TARGET} platform"
 }
-
-
-b_test_target() {
-	# FIXME: delete this function then PR, which fixes meterfs tests goes to `phoenix-rtos-tests` in `phoenix-pilot-project`
-	# https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/134
-
-	b_log "This project is do not support tests yet"
-}


### PR DESCRIPTION
JIRA: PP-99

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This PR adds ability to run tests form `phoenix-rtos-tests` on `host-generic-pilot` project.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `host-generic-pilot`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
